### PR TITLE
Make default server local

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -44,6 +44,8 @@ func NewConn(conn net.Conn, user string, password string, h Handler) (*Conn, err
 	p.AddUser(user, password)
 	salt, _ := RandomBuf(20)
 
+	defaultServer := NewDefaultServer()
+
 	var packetConn *packet.Conn
 	if defaultServer.tlsConfig != nil {
 		packetConn = packet.NewTLSConn(conn)

--- a/server/server_conf.go
+++ b/server/server_conf.go
@@ -8,8 +8,6 @@ import (
 	. "github.com/siddontang/go-mysql/mysql"
 )
 
-var defaultServer = NewDefaultServer()
-
 // Defines a basic MySQL server with configs.
 //
 // We do not aim at implementing the whole MySQL connection suite to have the best compatibilities for the clients.


### PR DESCRIPTION
Making `NewDefaultServer` is CPU intensive task since it generates keys/certificates, so move it out of a global variable.

The function where it's used, `NewConn`, is not used anywhere in Teleport's database access, but for now I opted for a less destructive fix than just completely removing it.