### PR TITLE
Send COM_QUIT on connection close.

### DIFF
--- a/client/conn.go
+++ b/client/conn.go
@@ -102,6 +102,11 @@ func (c *Conn) handshake() error {
 }
 
 func (c *Conn) Close() error {
+	if err := c.writeCommandUint32(COM_QUIT, c.connectionID); err != nil {
+		c.Conn.Close()
+		return errors.Trace(err)
+	}
+
 	return c.Conn.Close()
 }
 

--- a/client/conn.go
+++ b/client/conn.go
@@ -102,7 +102,7 @@ func (c *Conn) handshake() error {
 }
 
 func (c *Conn) Close() error {
-	if err := c.writeCommandUint32(COM_QUIT, c.connectionID); err != nil {
+	if err := c.writeCommand(COM_QUIT); err != nil {
 		c.Conn.Close()
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
`COM_QUIT` message is not being sent right before closing the DB connection which results in a warning printed in MariaDB logs

```
2022-03-01 18:42:01 9 [Warning] Aborted connection 9 to db: 'unconnected' user: 'alice' host: '192.168.0.248' (Got an error reading communication packets)
```

This PR adds the command which fixes the problem.