### PR TITLE
only make NewDefaultServer once when neccessary

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -47,7 +47,7 @@ func NewConn(conn net.Conn, user string, password string, h Handler) (*Conn, err
 	p.AddUser(user, password)
 
 	var packetConn *packet.Conn
-	if defaultServer.tlsConfig != nil {
+	if defaultServer().tlsConfig != nil {
 		packetConn = packet.NewTLSConn(conn)
 	} else {
 		packetConn = packet.NewConn(conn)
@@ -55,7 +55,7 @@ func NewConn(conn net.Conn, user string, password string, h Handler) (*Conn, err
 
 	c := &Conn{
 		Conn:               packetConn,
-		serverConf:         defaultServer,
+		serverConf:         defaultServer(),
 		credentialProvider: p,
 		h:                  h,
 		connectionID:       atomic.AddUint32(&baseConnID, 1),

--- a/server/server_conf.go
+++ b/server/server_conf.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/go-mysql-org/go-mysql/mysql"
 )
 
-var defaultServer = NewDefaultServer()
+var defaultServer = sync.OnceValue(NewDefaultServer)
 
 // Defines a basic MySQL server with configs.
 //


### PR DESCRIPTION
reapply #1 with sync.OnceValue

before:
```
stevehuang@mac ~/go/github.com/gravitational/teleport/lib/srv/db/mysql (master) $ GODEBUG='inittrace=1' go test  2>&1 | grep "go-mysql\/server"
init github.com/go-mysql-org/go-mysql/server @41 ms, 188 ms clock, 1528944 bytes, 13261 allocs
```

after:
```
stevehuang@mac ~/go/github.com/gravitational/teleport/lib/srv/db/mysql (master) $ GODEBUG='inittrace=1' go test  2>&1 | grep "go-mysql\/server"
# github.com/go-mysql-org/go-mysql/server
init github.com/go-mysql-org/go-mysql/server @35 ms, 0.019 ms clock, 792 bytes, 26 allocs
```